### PR TITLE
update tag/push to accept multiple values

### DIFF
--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -4,7 +4,7 @@
 [ -z "${INPUT_VERBOSITY}" ] && INPUT_VERBOSITY="error"
 
 # validate if values are set
-[ -z "${INPUT_TAG}" ]       && echo "INPUT_TAG is not set exiting" && exit 2
+[ -z "${INPUT_TAGS}" ]       && echo "INPUT_TAGS is not set exiting" && exit 2
 [ -z "${INPUT_VERBOSITY}" ] && exit "INPUT_VERBOSITY is not set exiting" && exit 2
 
 VERBOSITY=0
@@ -27,7 +27,7 @@ esac
 echo "POLICY-PUSH         $(/app/policy version | sed 's/Policy CLI.//g')"
 printf "\n"
 printf "\n"
-echo "INPUT_TAG           ${INPUT_TAG}"
+echo "INPUT_TAGS           ${INPUT_TAGS}"
 echo "INPUT_VERBOSITY     ${INPUT_VERBOSITY} (${VERBOSITY})"
 printf "\n"
 
@@ -36,14 +36,16 @@ printf "\n"
 #
 e_code=0
 
-# construct commandline arguments 
-CMD="/app/policy push ${INPUT_TAG} --verbosity=${VERBOSITY}"
+for TAG in ${INPUT_TAGS}; do
+  # construct commandline arguments
+  CMD="/app/policy push ${TAG} --verbosity=${VERBOSITY}"
 
-# execute command
-eval "$CMD" || e_code=1
-printf "\n"
+  # execute command
+  eval "$CMD" || e_code=1
+  printf "\n"
+done
 
-if [ "${VERBOSITY}" -ge "1" ]; then 
+if [ "${VERBOSITY}" -ge "1" ]; then
   /app/policy images --remote
   printf "\n"
 fi

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -5,7 +5,7 @@
 
 # validate if values are set
 [ -z "${INPUT_SOURCE_TAG}" ] && exit "INPUT_SOURCE_TAG is not set, exiting" && exit 2
-[ -z "${INPUT_TARGET_TAG}" ] && echo "INPUT_TARGET_TAG is not set, exiting" && exit 2
+[ -z "${INPUT_TARGET_TAGS}" ] && echo "INPUT_TARGET_TAGS is not set, exiting" && exit 2
 [ -z "${INPUT_VERBOSITY}" ]  && exit "INPUT_VERBOSITY is not set, exiting" && exit 2
 
 VERBOSITY=0
@@ -29,7 +29,7 @@ echo "POLICY-SAVE         $(/app/policy version | sed 's/Policy CLI.//g')"
 printf "\n"
 printf "\n"
 echo "INPUT_SOURCE_TAG    ${INPUT_SOURCE_TAG}"
-echo "INPUT_TARGET_TAG    ${INPUT_TARGET_TAG}"
+echo "INPUT_TARGET_TAGS    ${INPUT_TARGET_TAGS}"
 echo "INPUT_VERBOSITY     ${INPUT_VERBOSITY} (${VERBOSITY})"
 printf "\n"
 
@@ -38,11 +38,14 @@ printf "\n"
 #
 e_code=0
 
-# construct commandline arguments 
-CMD="/app/policy tag ${INPUT_SOURCE_TAG} ${INPUT_TARGET_TAG} --verbosity=${VERBOSITY}"
+for TAG in ${INPUT_TARGET_TAGS}; do
+  # construct commandline arguments
+  CMD="/app/policy tag ${INPUT_SOURCE_TAG} ${TAG} --verbosity=${VERBOSITY}"
+  echo "executing $CMD"
 
-# execute command
-eval "$CMD" || e_code=1
-printf "\n"
+  # execute command
+  eval "$CMD" || e_code=1
+  printf "\n"
+done
 
 exit $e_code


### PR DESCRIPTION
Updates `scripts/tag.sh` and `scripts/push.sh` to accept a list of tags to be usedin:
 - [policy-tag-action](https://github.com/opcr-io/policy-tag-action/commit/5c3170ccf7a47fb6a6bb5f4273bcf0ae62d2818e)
 - [policy-push-action](https://github.com/opcr-io/policy-push-action/commit/4644475d0590b6cc0bb6edc27d51e9f24404e21d)
- example job that uses the new actions: https://github.com/gimmyxd/test-release-action/blob/main/.github/workflows/build-release-policy.yaml