### PR TITLE
Use default http transport on windows

### DIFF
--- a/pkg/app/transport.go
+++ b/pkg/app/transport.go
@@ -23,7 +23,14 @@ func (c *PolicyApp) TransportWithTrustedCAs() *http.Transport {
 		if err != nil {
 			c.UI.Problem().WithErr(err).WithEnd(1).Msg("Failed to load system cert pool.")
 		}
+	} else {
+		// TODO: Remove runtime check when updating to go1.18 https://github.com/deviceinsight/kafkactl/issues/108
+		if len(c.Configuration.CA) > 0 {
+			c.UI.Exclamation().Msg("Cannot use custom CAs on Windows. Please configure your system store to trust your CAs.")
+		}
+		return http.DefaultTransport.(*http.Transport)
 	}
+
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
 	}


### PR DESCRIPTION
This PR will use the default http transport on windows and limit the use of custom CAs for now. When updating the project to go version 1.18 this code can be removed to run using the x509.SystemCertPool as intended. See https://github.com/deviceinsight/kafkactl/issues/108