### PR TITLE
Add documentation for installation via Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Wanna discuss features or show your support for this tool?
    ```
 
    home-manager:
-   ```shell
+   ```nix
      # your other config ...
      home.packages = with pkgs; [
        # your other packages ...

--- a/README.md
+++ b/README.md
@@ -43,6 +43,34 @@ Wanna discuss features or show your support for this tool?
   brew tap opcr-io/tap && brew install opcr-io/tap/policy
    ```
 
+* Via nixpkg for Linux, nixOS, and macOS
+
+   At the moment the package is only available in the unstable channel, below are some examples to install using the shell, NixOS, and home-manager.
+
+   Shell:
+   ```shell
+   nix-env --install -A nixpkgs.opcr-policy
+   ```
+
+   NixOS:
+   ```shell
+     # your other config ...
+     environment.systemPackages = with pkgs; [
+       # your other packages ...
+       opcr-policy
+     ];
+
+   ```
+
+   home-manager:
+   ```shell
+     # your other config ...
+     home.packages = with pkgs; [
+       # your other packages ...
+       opcr-policy
+     ];
+   ```
+
 * Via a GO install
 
   ```shell

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Wanna discuss features or show your support for this tool?
    ```
 
    NixOS:
-   ```shell
+   ```nix
      # your other config ...
      environment.systemPackages = with pkgs; [
        # your other packages ...

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Wanna discuss features or show your support for this tool?
 
 * Via nixpkg for Linux, nixOS, and macOS
 
-   At the moment the package is only available in the unstable channel, below are some examples to install using the shell, NixOS, and home-manager.
+   At the moment the package is only available in the `unstable` channel. Below are some examples using nix to install `policy` via the shell, NixOS configuration, and home-manager configuration.
 
    Shell:
    ```shell

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Wanna discuss features or show your support for this tool?
   brew tap opcr-io/tap && brew install opcr-io/tap/policy
    ```
 
-* Via nixpkg for Linux, nixOS, and macOS
+* Via the nix package manager on nixOS, other linux distros, and macOS
 
    At the moment the package is only available in the `unstable` channel. Below are some examples using nix to install `policy` via the shell, NixOS configuration, and home-manager configuration.
 


### PR DESCRIPTION
A few days ago I published policy into nixpkgs unstable (https://github.com/NixOS/nixpkgs/pull/194445), as this has now populated into the channel for general use, I figured it'd be a good idea to get some documentation written to let people know they can install this way too. 

I tried to follow a similar tone to the other methods but happy to rework the language or examples as anyone else sees fit!
