### PR TITLE
updated ocipolicytemplate_test to refer to valid policy repo

### DIFF
--- a/pkg/policytemplates/ocipolicytemplate_test.go
+++ b/pkg/policytemplates/ocipolicytemplate_test.go
@@ -18,7 +18,7 @@ func TestOCIListRepos(t *testing.T) {
 	log := zerolog.New(os.Stdout)
 	transport := &http.Transport{}
 	ctx := context.Background()
-	expectedRepo := "peoplefinder-rbac"
+	expectedRepo := "policy-peoplefinder-rbac"
 
 	ociTemplate := policytemplates.NewOCI(ctx, &log, transport, policytemplates.Config{
 		Server:     "opcr.io",


### PR DESCRIPTION
fix CI failure brought about by removing the (now invalid) peoplefinder-rbac opcr repo. 

replaced `peoplefinder-rbac` with `policy-peoplefinder-rbac`.