### PR TITLE
return exitcode(0)

### DIFF
--- a/cmd/policy/main.go
+++ b/cmd/policy/main.go
@@ -156,6 +156,7 @@ func main() {
 		&PolicyCLI,
 		kong.Name(appName),
 		kong.UsageOnError(),
+		kong.Exit(func(x int) { os.Exit(0) }),
 		kong.ConfigureHelp(kong.HelpOptions{
 			NoAppSummary:        false,
 			Summary:             false,


### PR DESCRIPTION
Before this change executing `policy` would return exit code 1

```
Usage: policy <command> [flags]

Commands:
  build        Build policies.
  images       List policy images.
  push         Push policies to a registry.
  pull         Pull policies from a registry.
  login        Login to a registry.
  logout       Logout from a registry.
  save         Save a policy to a local bundle tarball.
  tag          Create a new tag for an existing policy.
  rm           Removes a policy from the local registry.
  inspect      Displays information about a policy.
  repl         Sets you up with a shell for running queries using an OPA
               instance with a policy loaded.
  templates    List and apply templates
  version      Prints version information.

Flags:
  -h, --help         Show context-sensitive help.
  -c, --config="/Users/gertd/.config/policy/config.yaml"
                     Path to the policy CLI config file.
      --debug        Enable debug mode.
  -v, --verbosity    Use to increase output verbosity.
  -k, --insecure     Do not verify TLS connections.

Run "policy <command> --help" for more information on a command.

policy: error: expected one of "build",  "images",  "push",  "pull",  "login",  ...
Process 19229 has exited with status 1
```

This change override the exit handler to return exit code 0 instead.

All other error code paths continue to return exit code 1