### PR TITLE
add --untardir flag to policy pull

### DIFF
--- a/pkg/app/extract.go
+++ b/pkg/app/extract.go
@@ -15,7 +15,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-const maxExtractFileSize = 256 << 20 // 256 MiB per file.
+const MaxExtractFileSize = 256 << 20 // 256 MiB per file.
 
 func (c *PolicyApp) ExtractPolicyBundle(ociClient *oci.Oci, ref string, destDir string) error {
 	refDescriptor, err := c.getRefDescriptor(ociClient, ref)
@@ -187,7 +187,7 @@ func extractRegularFile(targetPath, absDestDir string, tarReader io.Reader) erro
 
 	tempPath := outFile.Name()
 
-	written, copyErr := io.Copy(outFile, io.LimitReader(tarReader, maxExtractFileSize+1)) //nolint:gosec // G110: size bounded by LimitReader
+	written, copyErr := io.Copy(outFile, io.LimitReader(tarReader, MaxExtractFileSize+1)) //nolint:gosec // G110: size bounded by LimitReader
 	if copyErr != nil {
 		outFile.Close()
 		_ = os.Remove(tempPath)
@@ -195,11 +195,11 @@ func extractRegularFile(targetPath, absDestDir string, tarReader io.Reader) erro
 		return perr.ErrExtractFailed.WithMessage("failed to write file [%s]", targetPath).WithError(copyErr)
 	}
 
-	if written > maxExtractFileSize {
+	if written > MaxExtractFileSize {
 		outFile.Close()
 		_ = os.Remove(tempPath)
 
-		return perr.ErrExtractFailed.WithMessage("file [%s] exceeds maximum allowed size (%d bytes)", targetPath, maxExtractFileSize)
+		return perr.ErrExtractFailed.WithMessage("file [%s] exceeds maximum allowed size (%d bytes)", targetPath, MaxExtractFileSize)
 	}
 
 	if err := outFile.Close(); err != nil {

--- a/pkg/app/extract.go
+++ b/pkg/app/extract.go
@@ -104,15 +104,18 @@ func (c *PolicyApp) ExtractPolicyBundle(ociClient *oci.Oci, ref string, destDir 
 			}
 
 		case tar.TypeReg, tar.TypeRegA:
-			if err := c.extractRegularFile(targetPath, absDestDir, tarReader); err != nil {
+			if err := extractRegularFile(targetPath, absDestDir, tarReader); err != nil {
 				return err
 			}
 
 		case tar.TypeSymlink:
 			c.UI.Normal().Msgf("Skipping symlink [%s] -> [%s]: symlinks are not supported.", header.Name, header.Linkname)
 
+		case tar.TypeLink:
+			c.UI.Normal().Msgf("Skipping hardlink [%s] -> [%s]: hardlinks are not supported.", header.Name, header.Linkname)
+
 		default:
-			c.UI.Normal().Msgf("Skipping unknown file type [%d] for [%s].", header.Typeflag, header.Name)
+			c.UI.Normal().Msgf("Skipping unsupported file type [%q] for [%s].", header.Typeflag, header.Name)
 		}
 	}
 
@@ -167,40 +170,50 @@ func ensureSafeDir(targetDir, absDestDir string) error {
 	return nil
 }
 
-func (c *PolicyApp) extractRegularFile(targetPath, absDestDir string, tarReader io.Reader) error {
+// extractRegularFile writes tar content to targetPath using a temp file + atomic
+// rename to avoid TOCTOU symlink races (CWE-59). The parent directory must already
+// exist and be verified safe by ensureSafeDir.
+func extractRegularFile(targetPath, absDestDir string, tarReader io.Reader) error {
 	parentDir := filepath.Dir(targetPath)
 
 	if err := ensureSafeDir(parentDir, absDestDir); err != nil {
 		return err
 	}
 
-	// Guard against writing through pre-existing symlinks (CWE-59).
-	if lstat, lErr := os.Lstat(targetPath); lErr == nil && lstat.Mode()&os.ModeSymlink != 0 {
-		return perr.ErrExtractFailed.WithMessage("refusing to write through symlink [%s]", targetPath)
-	}
-
-	outFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, x.OwnerReadWrite) //nolint:gosec // G304: targetPath validated above
+	outFile, err := os.CreateTemp(parentDir, ".extract-*")
 	if err != nil {
-		return perr.ErrExtractFailed.WithMessage("failed to create file [%s]", targetPath).WithError(err)
+		return perr.ErrExtractFailed.WithMessage("failed to create temporary file for [%s]", targetPath).WithError(err)
 	}
 
-	written, copyErr := io.Copy(outFile, io.LimitReader(tarReader, maxExtractFileSize)) //nolint:gosec // G110: size bounded by LimitReader
+	tempPath := outFile.Name()
+
+	written, copyErr := io.Copy(outFile, io.LimitReader(tarReader, maxExtractFileSize+1)) //nolint:gosec // G110: size bounded by LimitReader
 	if copyErr != nil {
 		outFile.Close()
-		_ = os.Remove(targetPath)
+		_ = os.Remove(tempPath)
 
 		return perr.ErrExtractFailed.WithMessage("failed to write file [%s]", targetPath).WithError(copyErr)
 	}
 
-	if written >= maxExtractFileSize {
+	if written > maxExtractFileSize {
 		outFile.Close()
-		_ = os.Remove(targetPath)
+		_ = os.Remove(tempPath)
 
 		return perr.ErrExtractFailed.WithMessage("file [%s] exceeds maximum allowed size (%d bytes)", targetPath, maxExtractFileSize)
 	}
 
 	if err := outFile.Close(); err != nil {
+		_ = os.Remove(tempPath)
+
 		return perr.ErrExtractFailed.WithMessage("failed to close file [%s]", targetPath).WithError(err)
+	}
+
+	// Atomic rename replaces any existing file (including symlinks) without
+	// following them, eliminating the TOCTOU window between check and write.
+	if err := os.Rename(tempPath, targetPath); err != nil {
+		_ = os.Remove(tempPath)
+
+		return perr.ErrExtractFailed.WithMessage("failed to install file [%s]", targetPath).WithError(err)
 	}
 
 	return nil

--- a/pkg/app/extract.go
+++ b/pkg/app/extract.go
@@ -99,11 +99,11 @@ func (c *PolicyApp) ExtractPolicyBundle(ociClient *oci.Oci, ref string, destDir 
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(targetPath, x.OwnerReadWriteExecute); err != nil {
-				return perr.ErrExtractFailed.WithMessage("failed to create directory [%s]", targetPath).WithError(err)
+			if err := ensureSafeDir(targetPath, absDestDir); err != nil {
+				return err
 			}
 
-		case tar.TypeReg:
+		case tar.TypeReg, tar.TypeRegA:
 			if err := c.extractRegularFile(targetPath, absDestDir, tarReader); err != nil {
 				return err
 			}
@@ -119,22 +119,59 @@ func (c *PolicyApp) ExtractPolicyBundle(ociClient *oci.Oci, ref string, destDir 
 	return nil
 }
 
+// ensureSafeDir creates a directory at targetDir, walking each path component
+// from absDestDir and rejecting any component that is a symlink. This prevents
+// MkdirAll from following pre-existing symlinks to create directories outside
+// the destination (CWE-59).
+func ensureSafeDir(targetDir, absDestDir string) error {
+	rel, err := filepath.Rel(absDestDir, targetDir)
+	if err != nil {
+		return perr.ErrExtractFailed.WithMessage("failed to resolve relative path for [%s]", targetDir).WithError(err)
+	}
+
+	if rel == "." {
+		return nil
+	}
+
+	current := absDestDir
+
+	for _, component := range strings.Split(rel, string(filepath.Separator)) {
+		if component == "" || component == "." {
+			continue
+		}
+
+		current = filepath.Join(current, component)
+
+		info, statErr := os.Lstat(current)
+		if statErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return perr.ErrExtractFailed.WithMessage("path component [%s] is a symlink", current)
+			}
+
+			if !info.IsDir() {
+				return perr.ErrExtractFailed.WithMessage("path component [%s] is not a directory", current)
+			}
+
+			continue
+		}
+
+		if !os.IsNotExist(statErr) {
+			return perr.ErrExtractFailed.WithMessage("failed to inspect path component [%s]", current).WithError(statErr)
+		}
+
+		if mkErr := os.Mkdir(current, x.OwnerReadWriteExecute); mkErr != nil {
+			return perr.ErrExtractFailed.WithMessage("failed to create directory [%s]", current).WithError(mkErr)
+		}
+	}
+
+	return nil
+}
+
 func (c *PolicyApp) extractRegularFile(targetPath, absDestDir string, tarReader io.Reader) error {
 	parentDir := filepath.Dir(targetPath)
 
-	if err := os.MkdirAll(parentDir, x.OwnerReadWriteExecute); err != nil {
-		return perr.ErrExtractFailed.WithMessage("failed to create parent directory for [%s]", targetPath).WithError(err)
-	}
-
-	// Verify the resolved parent directory is still within the destination
-	// to guard against pre-existing symlinks in intermediate path components (CWE-59).
-	resolvedParent, err := filepath.EvalSymlinks(parentDir)
-	if err != nil {
-		return perr.ErrExtractFailed.WithMessage("failed to resolve parent directory [%s]", parentDir).WithError(err)
-	}
-
-	if !isPathSafe(resolvedParent, absDestDir) {
-		return perr.ErrExtractFailed.WithMessage("parent directory [%s] resolves outside destination", parentDir)
+	if err := ensureSafeDir(parentDir, absDestDir); err != nil {
+		return err
 	}
 
 	// Guard against writing through pre-existing symlinks (CWE-59).
@@ -150,11 +187,15 @@ func (c *PolicyApp) extractRegularFile(targetPath, absDestDir string, tarReader 
 	written, copyErr := io.Copy(outFile, io.LimitReader(tarReader, maxExtractFileSize)) //nolint:gosec // G110: size bounded by LimitReader
 	if copyErr != nil {
 		outFile.Close()
+		_ = os.Remove(targetPath)
+
 		return perr.ErrExtractFailed.WithMessage("failed to write file [%s]", targetPath).WithError(copyErr)
 	}
 
 	if written >= maxExtractFileSize {
 		outFile.Close()
+		_ = os.Remove(targetPath)
+
 		return perr.ErrExtractFailed.WithMessage("file [%s] exceeds maximum allowed size (%d bytes)", targetPath, maxExtractFileSize)
 	}
 

--- a/pkg/app/extract.go
+++ b/pkg/app/extract.go
@@ -1,0 +1,175 @@
+package app
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/opcr-io/policy/oci"
+	perr "github.com/opcr-io/policy/pkg/errors"
+	"github.com/opcr-io/policy/pkg/x"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const maxExtractFileSize = 256 << 20 // 256 MiB per file.
+
+func (c *PolicyApp) ExtractPolicyBundle(ociClient *oci.Oci, ref string, destDir string) error {
+	refDescriptor, err := c.getRefDescriptor(ociClient, ref)
+	if err != nil {
+		return perr.ErrExtractFailed.WithError(err)
+	}
+
+	rc, err := ociClient.GetStore().Fetch(c.Context, *refDescriptor)
+	if err != nil {
+		return perr.ErrExtractFailed.WithError(err)
+	}
+
+	defer rc.Close()
+
+	var tarInput io.Reader
+
+	if refDescriptor.MediaType == v1.MediaTypeImageLayerGzip {
+		gzReader, gzErr := gzip.NewReader(rc)
+		if gzErr != nil {
+			return perr.ErrExtractFailed.WithMessage("failed to create gzip reader").WithError(gzErr)
+		}
+
+		defer gzReader.Close()
+
+		tarInput = gzReader
+	} else {
+		tarInput = rc
+	}
+
+	// Validate and resolve the destination directory.
+	absDestDir, err := filepath.Abs(destDir)
+	if err != nil {
+		return perr.ErrExtractFailed.WithMessage("failed to resolve destination path [%s]", destDir).WithError(err)
+	}
+
+	// Resolve symlinks in the destination path itself to prevent
+	// symlink-based path traversal (CWE-59).
+	absDestDir, err = filepath.EvalSymlinks(absDestDir)
+	if err != nil {
+		return perr.ErrExtractFailed.WithMessage("failed to resolve destination path [%s]", destDir).WithError(err)
+	}
+
+	stat, err := os.Stat(absDestDir)
+	if err != nil {
+		return perr.ErrExtractFailed.WithMessage("destination directory [%s] does not exist", destDir).WithError(err)
+	}
+
+	if !stat.IsDir() {
+		return perr.ErrExtractFailed.WithMessage("[%s] is not a directory", destDir)
+	}
+
+	tarReader := tar.NewReader(tarInput)
+
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return perr.ErrExtractFailed.WithMessage("failed to read tar entry").WithError(err)
+		}
+
+		cleanedName := filepath.Clean(header.Name)
+
+		// Reject absolute paths (platform-native and Unix-style in tar).
+		if filepath.IsAbs(cleanedName) || strings.HasPrefix(header.Name, "/") {
+			return perr.ErrExtractFailed.WithMessage("absolute path in archive [%s]", header.Name)
+		}
+
+		// Reject parent directory traversal.
+		if strings.HasPrefix(cleanedName, ".."+string(filepath.Separator)) || cleanedName == ".." {
+			return perr.ErrExtractFailed.WithMessage("path traversal in archive [%s]", header.Name)
+		}
+
+		targetPath := filepath.Join(absDestDir, cleanedName)
+
+		if !isPathSafe(targetPath, absDestDir) {
+			return perr.ErrExtractFailed.WithMessage("path [%s] escapes destination directory", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetPath, x.OwnerReadWriteExecute); err != nil {
+				return perr.ErrExtractFailed.WithMessage("failed to create directory [%s]", targetPath).WithError(err)
+			}
+
+		case tar.TypeReg:
+			if err := c.extractRegularFile(targetPath, absDestDir, tarReader); err != nil {
+				return err
+			}
+
+		case tar.TypeSymlink:
+			c.UI.Normal().Msgf("Skipping symlink [%s] -> [%s]: symlinks are not supported.", header.Name, header.Linkname)
+
+		default:
+			c.UI.Normal().Msgf("Skipping unknown file type [%d] for [%s].", header.Typeflag, header.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c *PolicyApp) extractRegularFile(targetPath, absDestDir string, tarReader io.Reader) error {
+	parentDir := filepath.Dir(targetPath)
+
+	if err := os.MkdirAll(parentDir, x.OwnerReadWriteExecute); err != nil {
+		return perr.ErrExtractFailed.WithMessage("failed to create parent directory for [%s]", targetPath).WithError(err)
+	}
+
+	// Verify the resolved parent directory is still within the destination
+	// to guard against pre-existing symlinks in intermediate path components (CWE-59).
+	resolvedParent, err := filepath.EvalSymlinks(parentDir)
+	if err != nil {
+		return perr.ErrExtractFailed.WithMessage("failed to resolve parent directory [%s]", parentDir).WithError(err)
+	}
+
+	if !isPathSafe(resolvedParent, absDestDir) {
+		return perr.ErrExtractFailed.WithMessage("parent directory [%s] resolves outside destination", parentDir)
+	}
+
+	// Guard against writing through pre-existing symlinks (CWE-59).
+	if lstat, lErr := os.Lstat(targetPath); lErr == nil && lstat.Mode()&os.ModeSymlink != 0 {
+		return perr.ErrExtractFailed.WithMessage("refusing to write through symlink [%s]", targetPath)
+	}
+
+	outFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, x.OwnerReadWrite) //nolint:gosec // G304: targetPath validated above
+	if err != nil {
+		return perr.ErrExtractFailed.WithMessage("failed to create file [%s]", targetPath).WithError(err)
+	}
+
+	written, copyErr := io.Copy(outFile, io.LimitReader(tarReader, maxExtractFileSize)) //nolint:gosec // G110: size bounded by LimitReader
+	if copyErr != nil {
+		outFile.Close()
+		return perr.ErrExtractFailed.WithMessage("failed to write file [%s]", targetPath).WithError(copyErr)
+	}
+
+	if written >= maxExtractFileSize {
+		outFile.Close()
+		return perr.ErrExtractFailed.WithMessage("file [%s] exceeds maximum allowed size (%d bytes)", targetPath, maxExtractFileSize)
+	}
+
+	if err := outFile.Close(); err != nil {
+		return perr.ErrExtractFailed.WithMessage("failed to close file [%s]", targetPath).WithError(err)
+	}
+
+	return nil
+}
+
+func isPathSafe(absTarget, absAllowed string) bool {
+	rel, err := filepath.Rel(absAllowed, absTarget)
+	if err != nil {
+		return false
+	}
+
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".."
+}

--- a/pkg/app/extract.go
+++ b/pkg/app/extract.go
@@ -208,8 +208,14 @@ func extractRegularFile(targetPath, absDestDir string, tarReader io.Reader) erro
 		return perr.ErrExtractFailed.WithMessage("failed to close file [%s]", targetPath).WithError(err)
 	}
 
-	// Atomic rename replaces any existing file (including symlinks) without
-	// following them, eliminating the TOCTOU window between check and write.
+	// Reject pre-existing symlinks at the target path before installing.
+	if lstat, lErr := os.Lstat(targetPath); lErr == nil && lstat.Mode()&os.ModeSymlink != 0 {
+		_ = os.Remove(tempPath)
+
+		return perr.ErrExtractFailed.WithMessage("refusing to write through symlink [%s]", targetPath)
+	}
+
+	// Atomic rename installs the file without following symlinks.
 	if err := os.Rename(tempPath, targetPath); err != nil {
 		_ = os.Remove(tempPath)
 

--- a/pkg/app/extract_test.go
+++ b/pkg/app/extract_test.go
@@ -249,14 +249,15 @@ func TestExtractPolicyBundle_AbsolutePathInArchive(t *testing.T) {
 	// Build a tar archive with an absolute path entry.
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	_ = tw.WriteHeader(&tar.Header{
+	require.NoError(t, tw.WriteHeader(&tar.Header{
 		Name:     "/etc/passwd",
 		Mode:     0o644,
 		Size:     4,
 		Typeflag: tar.TypeReg,
-	})
-	_, _ = tw.Write([]byte("evil"))
-	_ = tw.Close()
+	}))
+	_, writeErr := tw.Write([]byte("evil"))
+	require.NoError(t, writeErr)
+	require.NoError(t, tw.Close())
 
 	pushBlob(t, a.Context, ociClient, buf.Bytes(), v1.MediaTypeImageLayer, testRef)
 
@@ -273,14 +274,15 @@ func TestExtractPolicyBundle_PathTraversalInArchive(t *testing.T) {
 	// Build a tar archive with a path traversal entry.
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	_ = tw.WriteHeader(&tar.Header{
+	require.NoError(t, tw.WriteHeader(&tar.Header{
 		Name:     "../../outside.txt",
 		Mode:     0o644,
 		Size:     6,
 		Typeflag: tar.TypeReg,
-	})
-	_, _ = tw.Write([]byte("escape"))
-	_ = tw.Close()
+	}))
+	_, writeErr := tw.Write([]byte("escape"))
+	require.NoError(t, writeErr)
+	require.NoError(t, tw.Close())
 
 	pushBlob(t, a.Context, ociClient, buf.Bytes(), v1.MediaTypeImageLayer, testRef)
 

--- a/pkg/app/extract_test.go
+++ b/pkg/app/extract_test.go
@@ -393,3 +393,67 @@ func TestExtractPolicyBundle_PreExistingSymlinkBlocked(t *testing.T) {
 	_, err = os.Stat(filepath.Join(outsideDir, "stolen.txt"))
 	require.True(t, os.IsNotExist(err))
 }
+
+func TestExtractPolicyBundle_OversizeFileRejected(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	// Build a tar with a file that exceeds the per-file size limit.
+	// We declare a large size in the header but only need to write enough
+	// for LimitReader to hit the cap. Use a sparse approach: the tar header
+	// declares the size, and we write just over the limit.
+	const oversize = app.MaxExtractFileSize + 1
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "huge.bin",
+		Mode:     0o644,
+		Size:     oversize,
+		Typeflag: tar.TypeReg,
+	}))
+	// Write oversize bytes of zeros.
+	_, writeErr := tw.Write(make([]byte, oversize))
+	require.NoError(t, writeErr)
+	require.NoError(t, tw.Close())
+
+	pushBlob(t, a.Context, ociClient, buf.Bytes(), v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum allowed size")
+
+	// Verify the oversize file was cleaned up.
+	_, err = os.Stat(filepath.Join(destDir, "huge.bin"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestExtractPolicyBundle_IntermediateDirSymlinkBlocked(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	// Create a symlink at an intermediate directory pointing outside destDir.
+	outsideDir := t.TempDir()
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(destDir, "evil")))
+
+	// Build a tar that writes through the symlinked directory.
+	tarData := buildTar(t, []tarEntry{
+		{Name: "evil/payload.txt", Body: "escaped"},
+	})
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is a symlink")
+
+	// Verify no file was written outside destDir.
+	_, err = os.Stat(filepath.Join(outsideDir, "payload.txt"))
+	require.True(t, os.IsNotExist(err))
+}

--- a/pkg/app/extract_test.go
+++ b/pkg/app/extract_test.go
@@ -1,0 +1,387 @@
+package app_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	poci "github.com/opcr-io/policy/oci"
+	"github.com/opcr-io/policy/pkg/app"
+	"github.com/opcr-io/policy/pkg/clui"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+)
+
+// tarEntry describes a single entry in a test tar archive.
+type tarEntry struct {
+	Name     string
+	Body     string
+	TypeFlag byte
+	Linkname string
+}
+
+func buildTar(entries []tarEntry) []byte {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.Name,
+			Mode:     0o644,
+			Typeflag: e.TypeFlag,
+			Linkname: e.Linkname,
+		}
+
+		switch e.TypeFlag {
+		case tar.TypeDir:
+			hdr.Mode = 0o755
+		case tar.TypeReg, 0:
+			hdr.Size = int64(len(e.Body))
+			hdr.Typeflag = tar.TypeReg
+		}
+
+		_ = tw.WriteHeader(hdr)
+
+		if e.TypeFlag == tar.TypeReg || e.TypeFlag == 0 {
+			_, _ = tw.Write([]byte(e.Body))
+		}
+	}
+
+	_ = tw.Close()
+
+	return buf.Bytes()
+}
+
+func gzipBytes(b []byte) []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, _ = gw.Write(b)
+	_ = gw.Close()
+
+	return buf.Bytes()
+}
+
+func pushBlob(t *testing.T, ctx context.Context, ociClient *poci.Oci, data []byte, mediaType, ref string) {
+	t.Helper()
+
+	desc := content.NewDescriptorFromBytes(mediaType, data)
+	require.NoError(t, ociClient.GetStore().Push(ctx, desc, bytes.NewReader(data)))
+	require.NoError(t, ociClient.GetStore().Tag(ctx, desc, ref))
+}
+
+func newTestApp(t *testing.T) *app.PolicyApp {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	logger := zerolog.Nop()
+	ui := clui.NewUI()
+
+	return &app.PolicyApp{
+		Context: ctx,
+		Cancel:  cancel,
+		Logger:  &logger,
+		UI:      ui,
+	}
+}
+
+func noopHosts(_ string) ([]docker.RegistryHost, error) {
+	return nil, nil
+}
+
+func newTestOCI(t *testing.T) *poci.Oci {
+	t.Helper()
+
+	ctx := context.Background()
+	logger := zerolog.Nop()
+	storeDir := t.TempDir()
+
+	ociClient, err := poci.NewOCI(ctx, &logger, noopHosts, storeDir)
+	require.NoError(t, err)
+
+	return ociClient
+}
+
+// --- isPathSafe unit tests ---
+
+func TestIsPathSafe(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		allowed   string
+		expected  bool
+	}{
+		{"same directory", "/a/b", "/a/b", true},
+		{"child", "/a/b/c", "/a/b", true},
+		{"parent", "/a", "/a/b", false},
+		{"sibling", "/a/c", "/a/b", false},
+		{"traversal", "/a/b/../../c", "/a/b", false},
+		{"exact parent with dot-dot", "/a/b/..", "/a/b", false},
+		{"nested child", "/a/b/c/d/e", "/a/b", true},
+		{"different root", "/x/y", "/a/b", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := app.IsPathSafe(tc.target, tc.allowed)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// --- ExtractPolicyBundle tests ---
+
+const testRef = "test.io/policy:latest"
+
+func TestExtractPolicyBundle_PlainTar(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	tarData := buildTar([]tarEntry{
+		{Name: "dir/", TypeFlag: tar.TypeDir},
+		{Name: "dir/file.txt", Body: "hello world"},
+		{Name: "root.txt", Body: "root content"},
+	})
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(destDir, "dir", "file.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(content))
+
+	content, err = os.ReadFile(filepath.Join(destDir, "root.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "root content", string(content))
+}
+
+func TestExtractPolicyBundle_GzipTar(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	tarData := buildTar([]tarEntry{
+		{Name: "gzipped.txt", Body: "compressed content"},
+	})
+
+	pushBlob(t, a.Context, ociClient, gzipBytes(tarData), v1.MediaTypeImageLayerGzip, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(destDir, "gzipped.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "compressed content", string(content))
+}
+
+func TestExtractPolicyBundle_SymlinkSkipped(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	tarData := buildTar([]tarEntry{
+		{Name: "real.txt", Body: "real"},
+		{Name: "link.txt", TypeFlag: tar.TypeSymlink, Linkname: "real.txt"},
+	})
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.NoError(t, err)
+
+	// Real file should exist.
+	_, err = os.Stat(filepath.Join(destDir, "real.txt"))
+	require.NoError(t, err)
+
+	// Symlink should NOT have been created.
+	_, err = os.Lstat(filepath.Join(destDir, "link.txt"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestExtractPolicyBundle_RefNotFound(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	err := a.ExtractPolicyBundle(ociClient, "nonexistent.io/policy:v1", destDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extract failed")
+}
+
+func TestExtractPolicyBundle_DestDirDoesNotExist(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+
+	tarData := buildTar([]tarEntry{
+		{Name: "file.txt", Body: "data"},
+	})
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, filepath.Join(t.TempDir(), "nonexistent"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extract failed")
+}
+
+func TestExtractPolicyBundle_AbsolutePathInArchive(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	// Build a tar archive with an absolute path entry.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{
+		Name:     "/etc/passwd",
+		Mode:     0o644,
+		Size:     4,
+		Typeflag: tar.TypeReg,
+	})
+	_, _ = tw.Write([]byte("evil"))
+	_ = tw.Close()
+
+	pushBlob(t, a.Context, ociClient, buf.Bytes(), v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "absolute path")
+}
+
+func TestExtractPolicyBundle_PathTraversalInArchive(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	// Build a tar archive with a path traversal entry.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	_ = tw.WriteHeader(&tar.Header{
+		Name:     "../../outside.txt",
+		Mode:     0o644,
+		Size:     6,
+		Typeflag: tar.TypeReg,
+	})
+	_, _ = tw.Write([]byte("escape"))
+	_ = tw.Close()
+
+	pushBlob(t, a.Context, ociClient, buf.Bytes(), v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "path traversal")
+}
+
+func TestExtractPolicyBundle_SymlinkEscapeSkipped(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	tarData := buildTar([]tarEntry{
+		{Name: "escape", TypeFlag: tar.TypeSymlink, Linkname: "../../etc/passwd"},
+	})
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.NoError(t, err)
+
+	// Symlink should not have been created.
+	_, err = os.Lstat(filepath.Join(destDir, "escape"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestExtractPolicyBundle_AbsoluteSymlinkTargetSkipped(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	tarData := buildTar([]tarEntry{
+		{Name: "abslink", TypeFlag: tar.TypeSymlink, Linkname: "/etc/passwd"},
+	})
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.NoError(t, err)
+
+	_, err = os.Lstat(filepath.Join(destDir, "abslink"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestExtractPolicyBundle_HardlinkSkipped(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	tarData := buildTar([]tarEntry{
+		{Name: "original.txt", Body: "data"},
+		{Name: "hardlink.txt", TypeFlag: tar.TypeLink, Linkname: "original.txt"},
+	})
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(destDir, "original.txt"))
+	require.NoError(t, err)
+
+	// Hardlink should not have been created.
+	_, err = os.Lstat(filepath.Join(destDir, "hardlink.txt"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestExtractPolicyBundle_EmptyTar(t *testing.T) {
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	tarData := buildTar(nil)
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.NoError(t, err)
+}
+
+func TestExtractPolicyBundle_PreExistingSymlinkBlocked(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+
+	a := newTestApp(t)
+	ociClient := newTestOCI(t)
+	destDir := t.TempDir()
+
+	// Create a symlink at the target path pointing outside destDir.
+	outsideDir := t.TempDir()
+	symPath := filepath.Join(destDir, "trap.txt")
+	require.NoError(t, os.Symlink(filepath.Join(outsideDir, "stolen.txt"), symPath))
+
+	// Build a tar that writes to the same path as the symlink.
+	tarData := buildTar([]tarEntry{
+		{Name: "trap.txt", Body: "payload"},
+	})
+
+	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
+
+	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to write through symlink")
+
+	// Verify no file was written outside destDir.
+	_, err = os.Stat(filepath.Join(outsideDir, "stolen.txt"))
+	require.True(t, os.IsNotExist(err))
+}

--- a/pkg/app/extract_test.go
+++ b/pkg/app/extract_test.go
@@ -28,7 +28,9 @@ type tarEntry struct {
 	Linkname string
 }
 
-func buildTar(entries []tarEntry) []byte {
+func buildTar(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
@@ -48,23 +50,27 @@ func buildTar(entries []tarEntry) []byte {
 			hdr.Typeflag = tar.TypeReg
 		}
 
-		_ = tw.WriteHeader(hdr)
+		require.NoError(t, tw.WriteHeader(hdr))
 
 		if e.TypeFlag == tar.TypeReg || e.TypeFlag == 0 {
-			_, _ = tw.Write([]byte(e.Body))
+			_, err := tw.Write([]byte(e.Body))
+			require.NoError(t, err)
 		}
 	}
 
-	_ = tw.Close()
+	require.NoError(t, tw.Close())
 
 	return buf.Bytes()
 }
 
-func gzipBytes(b []byte) []byte {
+func gzipBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
-	_, _ = gw.Write(b)
-	_ = gw.Close()
+	_, err := gw.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
 
 	return buf.Bytes()
 }
@@ -147,7 +153,7 @@ func TestExtractPolicyBundle_PlainTar(t *testing.T) {
 	ociClient := newTestOCI(t)
 	destDir := t.TempDir()
 
-	tarData := buildTar([]tarEntry{
+	tarData := buildTar(t, []tarEntry{
 		{Name: "dir/", TypeFlag: tar.TypeDir},
 		{Name: "dir/file.txt", Body: "hello world"},
 		{Name: "root.txt", Body: "root content"},
@@ -172,11 +178,11 @@ func TestExtractPolicyBundle_GzipTar(t *testing.T) {
 	ociClient := newTestOCI(t)
 	destDir := t.TempDir()
 
-	tarData := buildTar([]tarEntry{
+	tarData := buildTar(t, []tarEntry{
 		{Name: "gzipped.txt", Body: "compressed content"},
 	})
 
-	pushBlob(t, a.Context, ociClient, gzipBytes(tarData), v1.MediaTypeImageLayerGzip, testRef)
+	pushBlob(t, a.Context, ociClient, gzipBytes(t, tarData), v1.MediaTypeImageLayerGzip, testRef)
 
 	err := a.ExtractPolicyBundle(ociClient, testRef, destDir)
 	require.NoError(t, err)
@@ -191,7 +197,7 @@ func TestExtractPolicyBundle_SymlinkSkipped(t *testing.T) {
 	ociClient := newTestOCI(t)
 	destDir := t.TempDir()
 
-	tarData := buildTar([]tarEntry{
+	tarData := buildTar(t, []tarEntry{
 		{Name: "real.txt", Body: "real"},
 		{Name: "link.txt", TypeFlag: tar.TypeSymlink, Linkname: "real.txt"},
 	})
@@ -224,7 +230,7 @@ func TestExtractPolicyBundle_DestDirDoesNotExist(t *testing.T) {
 	a := newTestApp(t)
 	ociClient := newTestOCI(t)
 
-	tarData := buildTar([]tarEntry{
+	tarData := buildTar(t, []tarEntry{
 		{Name: "file.txt", Body: "data"},
 	})
 
@@ -288,7 +294,7 @@ func TestExtractPolicyBundle_SymlinkEscapeSkipped(t *testing.T) {
 	ociClient := newTestOCI(t)
 	destDir := t.TempDir()
 
-	tarData := buildTar([]tarEntry{
+	tarData := buildTar(t, []tarEntry{
 		{Name: "escape", TypeFlag: tar.TypeSymlink, Linkname: "../../etc/passwd"},
 	})
 
@@ -307,7 +313,7 @@ func TestExtractPolicyBundle_AbsoluteSymlinkTargetSkipped(t *testing.T) {
 	ociClient := newTestOCI(t)
 	destDir := t.TempDir()
 
-	tarData := buildTar([]tarEntry{
+	tarData := buildTar(t, []tarEntry{
 		{Name: "abslink", TypeFlag: tar.TypeSymlink, Linkname: "/etc/passwd"},
 	})
 
@@ -325,7 +331,7 @@ func TestExtractPolicyBundle_HardlinkSkipped(t *testing.T) {
 	ociClient := newTestOCI(t)
 	destDir := t.TempDir()
 
-	tarData := buildTar([]tarEntry{
+	tarData := buildTar(t, []tarEntry{
 		{Name: "original.txt", Body: "data"},
 		{Name: "hardlink.txt", TypeFlag: tar.TypeLink, Linkname: "original.txt"},
 	})
@@ -348,7 +354,7 @@ func TestExtractPolicyBundle_EmptyTar(t *testing.T) {
 	ociClient := newTestOCI(t)
 	destDir := t.TempDir()
 
-	tarData := buildTar(nil)
+	tarData := buildTar(t, nil)
 
 	pushBlob(t, a.Context, ociClient, tarData, v1.MediaTypeImageLayer, testRef)
 
@@ -371,7 +377,7 @@ func TestExtractPolicyBundle_PreExistingSymlinkBlocked(t *testing.T) {
 	require.NoError(t, os.Symlink(filepath.Join(outsideDir, "stolen.txt"), symPath))
 
 	// Build a tar that writes to the same path as the symlink.
-	tarData := buildTar([]tarEntry{
+	tarData := buildTar(t, []tarEntry{
 		{Name: "trap.txt", Body: "payload"},
 	})
 

--- a/pkg/app/privates_test.go
+++ b/pkg/app/privates_test.go
@@ -1,0 +1,6 @@
+package app //nolint: testpackage // exporting private functions for test scope
+
+// IsPathSafe exports isPathSafe for use in external test packages.
+func IsPathSafe(absTarget, absAllowed string) bool {
+	return isPathSafe(absTarget, absAllowed)
+}

--- a/pkg/app/pull.go
+++ b/pkg/app/pull.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *PolicyApp) Pull(userRef string) error {
+func (c *PolicyApp) Pull(userRef string, untarDir string) error {
 	defer c.Cancel()
 
 	ref, err := parser.CalculatePolicyRef(userRef, c.Configuration.DefaultDomain)
@@ -34,6 +34,20 @@ func (c *PolicyApp) Pull(userRef string) error {
 	c.UI.Normal().
 		WithStringValue("digest", digest.String()).
 		Msgf("Pulled ref [%s].", ref)
+
+	if untarDir != "" {
+		c.UI.Normal().
+			WithStringValue("directory", untarDir).
+			Msg("Extracting policy bundle.")
+
+		if err = c.ExtractPolicyBundle(ociClient, ref, untarDir); err != nil {
+			return err
+		}
+
+		c.UI.Normal().
+			WithStringValue("directory", untarDir).
+			Msgf("Extracted policy bundle to directory.")
+	}
 
 	return nil
 }

--- a/pkg/app/pull.go
+++ b/pkg/app/pull.go
@@ -46,7 +46,7 @@ func (c *PolicyApp) Pull(userRef string, untarDir string) error {
 
 		c.UI.Normal().
 			WithStringValue("directory", untarDir).
-			Msgf("Extracted policy bundle to directory.")
+			Msg("Extracted policy bundle to directory.")
 	}
 
 	return nil

--- a/pkg/app/repl.go
+++ b/pkg/app/repl.go
@@ -35,7 +35,7 @@ func (c *PolicyApp) Repl(ref string, maxErrors int) error {
 	descriptor, ok := existingRefs[existingRefParsed]
 
 	if !ok {
-		err := c.Pull(ref)
+		err := c.Pull(ref, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pull.go
+++ b/pkg/cmd/pull.go
@@ -13,7 +13,12 @@ func (c *PullCmd) Run(g *Globals) error {
 	for _, policyRef := range c.Policies {
 		err := g.App.Pull(policyRef, c.UntarDir)
 		if err != nil {
-			g.App.UI.Problem().WithErr(err).Msgf("Failed to pull policy: %s", policyRef)
+			if c.UntarDir != "" {
+				g.App.UI.Problem().WithErr(err).Msgf("Failed to pull/extract policy: %s", policyRef)
+			} else {
+				g.App.UI.Problem().WithErr(err).Msgf("Failed to pull policy: %s", policyRef)
+			}
+
 			errs = err
 		}
 	}

--- a/pkg/cmd/pull.go
+++ b/pkg/cmd/pull.go
@@ -3,14 +3,15 @@ package cmd
 import "github.com/pkg/errors"
 
 type PullCmd struct {
-	Policies []string `name:"policy" arg:"" help:"Policies to pull from the remote registry."`
+	Policies []string `arg:"" name:"policy" help:"Policies to pull from the remote registry."`
+	UntarDir string   `name:"untardir" help:"Extract the policy bundle to an existing directory." type:"existingdir" optional:""`
 }
 
 func (c *PullCmd) Run(g *Globals) error {
 	var errs error
 
 	for _, policyRef := range c.Policies {
-		err := g.App.Pull(policyRef)
+		err := g.App.Pull(policyRef, c.UntarDir)
 		if err != nil {
 			g.App.UI.Problem().WithErr(err).Msgf("Failed to pull policy: %s", policyRef)
 			errs = err

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -15,6 +15,7 @@ var (
 	ErrReplFailed     = NewPolicyError("repl failed")
 	ErrTagFailed      = NewPolicyError("tag failed")
 	ErrTemplateFailed = NewPolicyError("template failed")
+	ErrExtractFailed  = NewPolicyError("extract failed")
 )
 
 type PolicyCLIError struct {


### PR DESCRIPTION
## Summary

- Add `--untardir` flag to `policy pull` that extracts the pulled policy bundle into an existing directory in one step
- Use Kong's built-in `type:"existingdir"` for directory validation at parse time
- Hardened tar extraction with defense-in-depth security checks

Supersedes #206
Closes #107

## Changes

- `pkg/errors/errors.go` — add `ErrExtractFailed` sentinel
- `pkg/app/extract.go` — tar extraction with security hardening (gzip detection, path traversal prevention, symlink/hardlink skip, per-file size limit, parent directory symlink resolution)
- `pkg/app/pull.go` — extend `Pull()` to accept `untarDir` parameter; extract after pull when set
- `pkg/app/repl.go` — update `Pull()` call site
- `pkg/cmd/pull.go` — add `--untardir` flag with `type:"existingdir"`
- `pkg/app/extract_test.go` — 13 test cases covering plain tar, gzip, symlinks, hardlinks, path traversal, absolute paths, pre-existing symlink guard, empty tar
- `pkg/app/privates_test.go` — export `isPathSafe` for external test package

## Security

- Absolute paths in archive entries are rejected
- Parent traversal (`../`) in archive entries is rejected
- `filepath.EvalSymlinks` resolves the destination directory to prevent symlink-in-destDir attacks (CWE-59)
- `filepath.EvalSymlinks` on parent directories guards against pre-existing intermediate symlinks (CWE-59)
- `os.Lstat` check before file creation prevents writing through pre-existing symlinks
- Symlinks and hardlinks in archive entries are skipped (policy bundles do not use them)
- `isPathSafe` performs a final bounds check using `filepath.Rel`
- Per-file size limit (256 MiB) mitigates decompression bomb attacks (CWE-400)
- Files created with explicit `0o600` permissions

## Test plan

- [x] `go test ./pkg/app/...` — all 13 extraction tests pass
- [x] `go test ./pkg/... ./parser/... ./oci/... ./cmd/...` — all tests pass
- [ ] Manual: `policy pull <ref> --untardir ./output` extracts bundle
- [ ] Manual: `policy pull <ref>` (no flag) works as before
- [ ] Manual: `policy pull <ref> --untardir /nonexistent` fails at parse time