### PR TITLE
fix userHome message on policy config

### DIFF
--- a/cmd/policy/main.go
+++ b/cmd/policy/main.go
@@ -49,7 +49,10 @@ func run() int {
 			Indenter:            kong.SpaceIndenter,
 			NoExpandSubcommands: true,
 		}),
-		kong.Resolvers(cmd.ConfigExpander()), kong.Vars{"userHome": home},
+		kong.Resolvers(cmd.ConfigExpander()),
+		kong.Vars{
+			"userHome": home,
+		},
 	)
 
 	g := &cmd.Globals{

--- a/pkg/cmd/cli.go
+++ b/pkg/cmd/cli.go
@@ -105,7 +105,7 @@ type Globals struct {
 }
 
 type CLI struct {
-	Config    string       `flag:"" short:"c" type:"path" help:"Path to the policy CLI config file." default:"${userHome}/.config/policy/config.yaml"`
+	Config    string       `flag:"" short:"c" type:"path" help:"Path to the policy CLI config file." default:"${userHome}/.policy/config.yaml"`
 	Debug     bool         `flag:"" help:"Enable debug mode."`
 	Verbosity int          `flag:"" short:"v" type:"counter" help:"Use to increase output verbosity."`
 	Insecure  bool         `flag:"" short:"k" help:"Do not verify TLS connections."`


### PR DESCRIPTION
The CLI handler used an incorrect default value for the config file path:

```
default:"${userHome}/.config/policy/config.yaml" 
```

which does not exist as the path used is

```
default:"${userHome}/.policy/config.yaml"
```

This only updates the default value displayed in the CLI.